### PR TITLE
anaconda-catalogs 0.2.0 rebuild py314

### DIFF
--- a/abs.yaml
+++ b/abs.yaml
@@ -1,0 +1,2 @@
+build_env_vars:
+  ANACONDA_ROCKET_ENABLE_PY314 : yes

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -5,7 +5,7 @@ package:
   version: {{ version }}
 
 source:
-  url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
+  url: https://pypi.org/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
   sha256: 9f9396ced850ec377fd6ef0d9be43bb6f62dd0a61da69582d077458e3bb12e7d
 
 build:
@@ -26,7 +26,7 @@ requirements:
     - aiohttp
     - intake
     - requests
-    - jinja2 # extra needed by intake for catalogs utils
+    - jinja2    # extra needed by intake for catalogs utils
 
 test:
   source_files:
@@ -34,6 +34,7 @@ test:
   imports:
     - anaconda_catalogs
   requires:
+    - pip
     - pytest
   commands:
     - pip check

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -9,7 +9,7 @@ source:
   sha256: 9f9396ced850ec377fd6ef0d9be43bb6f62dd0a61da69582d077458e3bb12e7d
 
 build:
-  number: 2
+  number: 3
   skip: true  # [py<38]
   script: {{ PYTHON }} -m pip install . -vv --no-deps --no-build-isolation --ignore-installed
 
@@ -18,7 +18,7 @@ requirements:
     - python
     - pip
     - setuptools
-    - setuptools-scm
+    - setuptools-scm >=6.2
     - toml
     - wheel
   run:
@@ -36,7 +36,9 @@ test:
   requires:
     - pytest
   commands:
-    - pytest
+    - pip check
+    - python -c "from importlib.metadata import version; assert(version('{{ name }}')=='{{ version }}')"
+    - pytest -ra -v
 
 about:
   home: https://github.com/anaconda/anaconda-cloud-tools


### PR DESCRIPTION
anaconda-catalogs 0.2.0 

**Destination channel:** Defaults

### Links

- [PKG-10925]
- dev_url:        https://github.com/anaconda/anaconda-cloud-tools/tree/
- conda_forge:    https://github.com/conda-forge/anaconda-catalogs-feedstock
- pypi:           https://pypi.org/project/anaconda-catalogs/0.2.0
- pypi inspector: https://inspector.pypi.io/project/anaconda-catalogs/0.2.0

### Explanation of changes:

- rebuild py314


[PKG-10925]: https://anaconda.atlassian.net/browse/PKG-10925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ